### PR TITLE
#1 Support webpack's new hooks API in addition to old Tapable.plugin API

### DIFF
--- a/webpack-beep-plugin.js
+++ b/webpack-beep-plugin.js
@@ -5,9 +5,14 @@ function CompileBeepPlugin(options) {
 }
 
 CompileBeepPlugin.prototype.apply = function(compiler) {
-    compiler.plugin('done', function() {
+    const onCompileDone = () => {
         enable && alertTerminal();
-    });
+    };
+    if (compiler.hooks) {
+        compiler.hooks.done.tap('CompileBeepPlugin', onCompileDone);
+    } else {
+        compiler.plugin('done', onCompileDone);
+    }
 };
 
 function alertTerminal(){


### PR DESCRIPTION
This replaces #2.

> Thanks for your pull request. I don't know how many people are using this package, but we should probably make it backward compatible.
> If you can check for compiler.hooks first and then use the appropriate method that would be fantastic. If you don't want to do that work, I can look into doing it.

Is this what you meant? I only tested the first code path of this change.