### PR TITLE
Make webpack a peer dependency and update to v4/v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "url": "https://github.com/scottburch/webpack-beep-plugin/issues"
   },
   "homepage": "https://github.com/scottburch/webpack-beep-plugin#readme",
-  "dependencies": {
-    "webpack": "^1.12.4"
+  "peerDependencies": {
+    "webpack": "^4.0.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "webpack": "5.11.1"
   }
 }


### PR DESCRIPTION
Without this, NPM ends up installing webpack v1 when using the beep plugin.

This is based on how other plugins configure their dependencies (e.g. the html-webpack-plugin), but it's untested.